### PR TITLE
config.json: Add Generic x86_64

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,6 +66,11 @@
       "repo": "balena-os/balena-compulab"
     },
     {
+      "name": "Generic x86_64",
+      "slug": "genericx86-64-ext",
+      "repo": "balena-os/balena-intel",
+    },
+    {
       "name": "Hummingboard",
       "slug": "hummingboard",
       "repo": "balena-os/balena-fsl-arm",


### PR DESCRIPTION
Add the Generic x86_64 board to the boards list

Signed-off-by: Florin Sarbu <florin@balena.io>